### PR TITLE
fix(commands): rename command prefix to titanium

### DIFF
--- a/lib/appc.js
+++ b/lib/appc.js
@@ -371,7 +371,7 @@ const Appc = {
 	},
 
 	/**
-	 * Run `appc new` command to generate new Titanium app project
+	 * Run `ti create` command to generate new Titanium app project
 	 *
 	 * @param {Object} opts						arguments
 	 * @param {String} opts.id 	    			app ID
@@ -438,7 +438,7 @@ const Appc = {
 	},
 
 	/**
-	 * Show appc command error with link to package settings
+	 * Show command error with link to package settings
 	 *
 	 * @param {String} message 		message title
 	 */
@@ -451,7 +451,7 @@ const Appc = {
 	},
 
 	/**
-	 * Run `appc ti clean` command
+	 * Run `ti clean` command
 	 * @returns {BufferedProcess}
 	 * @param {Object} opts The options to pass to the clean command.
 	 *

--- a/lib/index.js
+++ b/lib/index.js
@@ -173,7 +173,7 @@ export default {
 
 		this.disposable.add(
 			atom.commands.add('atom-workspace', {
-				'appc:new': () => {
+				'titanium:new': () => {
 					this.openNewProjectDialog();
 				}
 			}),
@@ -185,7 +185,7 @@ export default {
 						type: 'separator'
 					}, {
 						label: 'New Titanium Project...',
-						command: 'appc:new'
+						command: 'titanium:new'
 					} ]
 				} ]
 			} ]),
@@ -244,24 +244,24 @@ export default {
 
 			this.projectDisposable.add(
 				atom.commands.add('atom-workspace', {
-					'appc:build': () => {
+					'titanium:build': () => {
 						if (Project.isTitaniumApp || Project.isTitaniumModule) {
 							this.runBuildCommand();
 						}
 					},
-					'appc:stop': () => {
+					'titanium:stop': () => {
 						this.stopBuildCommand();
 					},
-					'appc:console:toggle': () => {
+					'titanium:console:toggle': () => {
 						this.console.toggle();
 					},
-					'appc:clean': () => {
+					'titanium:clean': () => {
 						if (Project.isTitaniumApp || Project.isTitaniumModule) {
 							this.runCleanCommand();
 						}
 					},
-					'appc:toolbar:toggle': {
-						displayName: 'Appc: Toggle Toolbar',
+					'titanium:toolbar:toggle': {
+						displayName: 'Titanium: Toggle Toolbar',
 						didDispatch: () => {
 							if (!this.toolbar) {
 								return;
@@ -269,10 +269,10 @@ export default {
 							this.toolbar.toggle();
 						}
 					},
-					'appc:update:refresh': () => {
+					'titanium:update:refresh': () => {
 						this.checkForUpdates();
 					},
-					'appc:generate-completions': () => {
+					'titanium:generate-completions': () => {
 						autoCompleteHelper.generateAutoCompleteSuggestions({ force: true });
 					}
 				}),
@@ -300,24 +300,24 @@ export default {
 				menu = require('./menu/app');
 				this.projectDisposable.add(
 					atom.commands.add('atom-workspace', {
-						'appc:generate': () => this.openGenerateDialog(),
-						'appc:open-related-view': () => related.openRelatedFile('xml'),
-						'appc:open-related-style': () => related.openRelatedFile('tss'),
-						'appc:open-related-controller': () => related.openRelatedFile('js'),
-						'appc:open-or-close-related': () => related.toggleAllRelatedFiles(),
-						'appc:take-screenshot': () => this.takeScreenshot(),
-						'appc:updates': () => this.openUpdatesDialog(),
-						// 'appc:closeRelated': () => related.closeRelatedFiles({forceAllClose: true})
+						'titanium:generate': () => this.openGenerateDialog(),
+						'titanium:open-related-view': () => related.openRelatedFile('xml'),
+						'titanium:open-related-style': () => related.openRelatedFile('tss'),
+						'titanium:open-related-controller': () => related.openRelatedFile('js'),
+						'titanium:open-or-close-related': () => related.toggleAllRelatedFiles(),
+						'titanium:take-screenshot': () => this.takeScreenshot(),
+						'titanium:updates': () => this.openUpdatesDialog(),
+						// 'titanium:closeRelated': () => related.closeRelatedFiles({forceAllClose: true})
 					})
 				);
 
 				// add contect menu
 				atom.contextMenu.add({
 					'atom-workspace': [
-						{ label: 'Open related view', command: 'appc:open-related-view', shouldDisplay: () => this.checkShouldDisplay('xml') },
-						{ label: 'Open related style', command: 'appc:open-related-style', shouldDisplay: () => this.checkShouldDisplay('tss') },
-						{ label: 'Open related controller', command: 'appc:open-related-controller', shouldDisplay: () => this.checkShouldDisplay('js') },
-						{ label: 'Open/Close all related', command: 'appc:open-or-close-related', shouldDisplay: () => this.checkShouldDisplay('') }
+						{ label: 'Open related view', command: 'titanium:open-related-view', shouldDisplay: () => this.checkShouldDisplay('xml') },
+						{ label: 'Open related style', command: 'titanium:open-related-style', shouldDisplay: () => this.checkShouldDisplay('tss') },
+						{ label: 'Open related controller', command: 'titanium:open-related-controller', shouldDisplay: () => this.checkShouldDisplay('js') },
+						{ label: 'Open/Close all related', command: 'titanium:open-or-close-related', shouldDisplay: () => this.checkShouldDisplay('') }
 					]
 				});
 			} else {
@@ -383,7 +383,7 @@ export default {
 			tbItem: new TouchBarButton({
 				icon: nativeImage.createFromNamedImage('NSTouchBarPlayTemplate', [ -1, 0, 1 ]),
 				click: () => {
-					atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:build');
+					atom.commands.dispatch(atom.views.getView(atom.workspace), 'titanium:build');
 				}
 			}),
 			place: 1
@@ -394,7 +394,7 @@ export default {
 			tbItem: new TouchBarButton({
 				icon: nativeImage.createFromNamedImage('NSTouchBarDeleteTemplate', [ -1, 0, 1 ]),
 				click: () => {
-					atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:clean');
+					atom.commands.dispatch(atom.views.getView(atom.workspace), 'titanium:clean');
 				}
 			}),
 			place: 2
@@ -428,7 +428,7 @@ export default {
 								tbItem: new TouchBarButton({
 									label: 'All',
 									click: () => {
-										atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:open-or-close-related');
+										atom.commands.dispatch(atom.views.getView(atom.workspace), 'titanium:open-or-close-related');
 										addBackItems();
 									}
 								}),
@@ -439,7 +439,7 @@ export default {
 								tbItem: new TouchBarButton({
 									label: 'Controller',
 									click: () => {
-										atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:open-related-controller');
+										atom.commands.dispatch(atom.views.getView(atom.workspace), 'titanium:open-related-controller');
 										addBackItems();
 
 									}
@@ -451,7 +451,7 @@ export default {
 								tbItem: new TouchBarButton({
 									label: 'Style',
 									click: () => {
-										atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:open-related-style');
+										atom.commands.dispatch(atom.views.getView(atom.workspace), 'titanium:open-related-style');
 										addBackItems();
 
 									}
@@ -463,7 +463,7 @@ export default {
 								tbItem: new TouchBarButton({
 									label: 'View',
 									click: () => {
-										atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:open-related-view');
+										atom.commands.dispatch(atom.views.getView(atom.workspace), 'titanium:open-related-view');
 										addBackItems();
 									}
 								}),
@@ -664,7 +664,7 @@ export default {
 				tbItem: new TouchBarButton({
 					icon: nativeImage.createFromNamedImage('NSTouchBarRecordStopTemplate', [ -1, 0, 1 ]),
 					click: () => {
-						atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:stop');
+						atom.commands.dispatch(atom.views.getView(atom.workspace), 'titanium:stop');
 					}
 				}),
 				toReplace: 'build'
@@ -689,7 +689,7 @@ export default {
 				tbItem: new TouchBarButton({
 					icon: nativeImage.createFromNamedImage('NSTouchBarPlayTemplate', [ -1, 0, 1 ]),
 					click: () => {
-						atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:build');
+						atom.commands.dispatch(atom.views.getView(atom.workspace), 'titanium:build');
 					}
 				}),
 				toReplace: 'stop'
@@ -861,7 +861,7 @@ export default {
 
 		const setupTargets = () => {
 			// It's possible that the plugin has been unloaded as the folder was removed whilst
-			// we were running appc info. So check for the existence of the toolbar and return
+			// we were running ti info. So check for the existence of the toolbar and return
 			if (!this.toolbar) {
 				return;
 			}

--- a/lib/keymap/app.js
+++ b/lib/keymap/app.js
@@ -1,10 +1,10 @@
 module.exports = {
 	'atom-workspace': {
-		'ctrl-alt-enter': 'appc:build',
-		'ctrl-alt-v': 'appc:open-related-view',
-		'ctrl-alt-s': 'appc:open-related-style',
-		'ctrl-alt-x': 'appc:open-related-controller',
-		'ctrl-alt-a': 'appc:open-or-close-related',
-		'ctrl-alt-k': 'appc:clean'
+		'ctrl-alt-enter': 'titanium:build',
+		'ctrl-alt-v': 'titanium:open-related-view',
+		'ctrl-alt-s': 'titanium:open-related-style',
+		'ctrl-alt-x': 'titanium:open-related-controller',
+		'ctrl-alt-a': 'titanium:open-or-close-related',
+		'ctrl-alt-k': 'titanium:clean'
 	}
 };

--- a/lib/keymap/module.js
+++ b/lib/keymap/module.js
@@ -1,5 +1,5 @@
 module.exports = {
 	'atom-workspace': {
-		'ctrl-alt-enter': 'appc:build'
+		'ctrl-alt-enter': 'titanium:build'
 	}
 };

--- a/lib/menu/app.js
+++ b/lib/menu/app.js
@@ -6,17 +6,17 @@ module.exports = {
 				{
 					label: 'Titanium SDK',
 					submenu: [
-						{ label: 'Add Component', command: 'appc:generate' },
-						{ label: 'Build', command: 'appc:build' },
-						{ label: 'Clean Project', command: 'appc:clean' },
-						{ label: 'Take Screenshot', command: 'appc:take-screenshot' },
-						{ label: 'Toggle Console', command: 'appc:console:toggle' },
-						{ label: 'Toggle related Files', command: 'appc:open-or-close-related' },
-						{ label: 'Toggle Toolbar', command: 'appc:toolbar:toggle' },
-						{ label: 'Open related Controller…', command: 'appc:open-related-controller' },
-						{ label: 'Open related Style…', command: 'appc:open-related-style' },
-						{ label: 'Open related View…', command: 'appc:open-related-view' },
-						{ label: 'Check For Updates', command: 'appc:update:refresh' }
+						{ label: 'Add Component', command: 'titanium:generate' },
+						{ label: 'Build', command: 'titanium:build' },
+						{ label: 'Clean Project', command: 'titanium:clean' },
+						{ label: 'Take Screenshot', command: 'titanium:take-screenshot' },
+						{ label: 'Toggle Console', command: 'titanium:console:toggle' },
+						{ label: 'Toggle related Files', command: 'titanium:open-or-close-related' },
+						{ label: 'Toggle Toolbar', command: 'titanium:toolbar:toggle' },
+						{ label: 'Open related Controller…', command: 'titanium:open-related-controller' },
+						{ label: 'Open related Style…', command: 'titanium:open-related-style' },
+						{ label: 'Open related View…', command: 'titanium:open-related-view' },
+						{ label: 'Check For Updates', command: 'titanium:update:refresh' }
 					]
 				}
 			]

--- a/lib/menu/module.js
+++ b/lib/menu/module.js
@@ -6,7 +6,7 @@ module.exports = {
 				{
 					label: 'Titanium SDK',
 					submenu: [
-						{ label: 'Build', command: 'appc:build' }
+						{ label: 'Build', command: 'titanium:build' }
 					]
 				}
 			]

--- a/lib/ui/hud.jsx
+++ b/lib/ui/hud.jsx
@@ -118,6 +118,6 @@ export default class Hud {
 	}
 
 	updatesButtonClicked() {
-		atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:updates');
+		atom.commands.dispatch(atom.views.getView(atom.workspace), 'titanium:updates');
 	}
 }

--- a/lib/ui/toolbar.jsx
+++ b/lib/ui/toolbar.jsx
@@ -626,7 +626,7 @@ export default class Toolbar {
 	 * Build button clicked
 	 */
 	buildButtonClicked() {
-		let command = (this.state.buildInProgress) ? 'appc:stop' : 'appc:build';
+		let command = (this.state.buildInProgress) ? 'titanium:stop' : 'titanium:build';
 		atom.commands.dispatch(atom.views.getView(atom.workspace), command);
 	}
 
@@ -767,14 +767,14 @@ export default class Toolbar {
 	 * Generate button clicked
 	 */
 	generateButtonClicked() {
-		atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:generate');
+		atom.commands.dispatch(atom.views.getView(atom.workspace), 'titanium:generate');
 	}
 
 	/**
 	 * Console button clicked
 	 */
 	toggleConsoleButtonClicked() {
-		atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:console:toggle');
+		atom.commands.dispatch(atom.views.getView(atom.workspace), 'titanium:console:toggle');
 	}
 
 	/**
@@ -813,6 +813,6 @@ export default class Toolbar {
 	 * Dispatch the clean command when the clean button is clicked
 	 */
 	cleanProjectButtonClicked() {
-		atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:clean');
+		atom.commands.dispatch(atom.views.getView(atom.workspace), 'titanium:clean');
 	}
 }


### PR DESCRIPTION
The current commands have an `appc` prefix, this switches it to a `titanium` prefix, arguably a breaking change but I think we can get away with it