### PR TITLE
feat: alloy checkbox when creating a new project

### DIFF
--- a/lib/appc.js
+++ b/lib/appc.js
@@ -378,12 +378,12 @@ const Appc = {
 	 * @param {String} opts.name   				app name
 	 * @param {String} opts.location  			parent directory for project
 	 * @param {Array} opts.platforms 			app platforms
-	 * @param {Boolean} opts.enableServices		enable platform services
+	 * @param {Boolean} opts.enableAlloy		enable alloy
 	 */
 	new(opts) {
 		const args = Utils.createAppArguments({
 			id: opts.id,
-			enableServices: opts.enableServices,
+			enableAlloy: opts.enableAlloy,
 			name: opts.name,
 			platforms: opts.platforms,
 			workspaceDir: opts.location
@@ -394,7 +394,7 @@ const Appc = {
 			if (code === 0) {
 				// spawn process to open project in new window
 				return new BufferedProcess({
-					command: 'atom',
+					command: 'pulsar',
 					args: [ projectDir ]
 				});
 			} else {
@@ -412,21 +412,25 @@ const Appc = {
 					return handleFinish(code);
 				}
 
-				opts.log && opts.log('Creating Alloy app');
-				// create an alloy app now!
-				const proc = new BufferedProcess({
-					command: 'alloy',
-					args: [ 'new' ],
-					options: { cwd: projectDir },
-					stdout: output => opts.log && opts.log(output, proc),
-					stderr: output => opts.error && opts.error(output),
-					exit: code => handleFinish(code)
-				});
-				proc.onWillThrowError(error => {
-					this.showCommandError('Error creating Alloy project');
-					error.handle();
-					opts.exit && opts.exit();
-				});
+				if (opts.enableAlloy) {
+					opts.log && opts.log('Creating Alloy app');
+					// create an alloy app now!
+					const proc = new BufferedProcess({
+						command: 'alloy',
+						args: [ 'new' ],
+						options: { cwd: projectDir },
+						stdout: output => opts.log && opts.log(output, proc),
+						stderr: output => opts.error && opts.error(output),
+						exit: code => handleFinish(code)
+					});
+					proc.onWillThrowError(error => {
+						this.showCommandError('Error creating Alloy project');
+						error.handle();
+						opts.exit && opts.exit();
+					});
+				} else {
+					handleFinish(code);
+				}
 			}
 		});
 

--- a/lib/appc.js
+++ b/lib/appc.js
@@ -383,7 +383,6 @@ const Appc = {
 	new(opts) {
 		const args = Utils.createAppArguments({
 			id: opts.id,
-			enableAlloy: opts.enableAlloy,
 			name: opts.name,
 			platforms: opts.platforms,
 			workspaceDir: opts.location

--- a/lib/ui/newProjectDialog.jsx
+++ b/lib/ui/newProjectDialog.jsx
@@ -27,13 +27,15 @@ export default class NewProjectDialog {
 			focus: 'name',
 			submitButtonEnabled: false,
 			locationExists: false,
-			executing: false
+			executing: false,
+			enableAlloy: true
 		};
 		this.project = {
 			name: '',
 			id: '',
 			platforms: Utils.platforms(),
-			location: homedir()
+			location: homedir(),
+			enableAlloy: true
 		};
 		etch.initialize(this);
 		this.setFocus();
@@ -97,6 +99,12 @@ export default class NewProjectDialog {
 					<Button flat="true" icon="file-directory" disabled={this.state.executing} click={this.locationButtonClicked.bind(this)} />
 				</div>
 				{projectLocation}
+
+				<div className="row">
+					<div className="title">Enable Alloy:</div>
+					<input className="input-checkbox" type="checkbox" ref="enableAlloy" disabled={this.state.executing} checked={this.project.enableAlloy} on={{ change: this.enableAlloyDidChange }} />
+				</div>
+
 				<div className="row-buttons">
 					<button className="btn" attributes={{ tabindex: '10' }} disabled={this.state.executing} on={{ click: this.cancelButtonClicked }}>Cancel</button>
 					<button className="btn btn-primary inline-block-tight" ref="submit" disabled={!this.state.submitButtonEnabled || this.state.executing} attributes={{ tabindex: '11' }} on={{ click: this.submitButtonClicked }}>Create</button>
@@ -196,8 +204,8 @@ export default class NewProjectDialog {
 	/**
 	 * Enable services checkbox did change
 	 */
-	enableServicesDidChange() {
-		this.project.enableServices = this.refs.enableServices.checked;
+	enableAlloyDidChange() {
+		this.project.enableAlloy = this.refs.enableAlloy.checked;
 		etch.update(this);
 	}
 

--- a/spec/definitionsProvider-spec.js
+++ b/spec/definitionsProvider-spec.js
@@ -28,7 +28,7 @@ describe('Definition suggestions', () => {
 	before(async function ()  {
 		this.timeout(5000);
 		sandbox = sinon.createSandbox();
-		atom.project.setPaths([path.join(__dirname, 'data', 'fixtures', 'alloy-project')]);
+		atom.project.setPaths([ path.join(__dirname, 'data', 'fixtures', 'alloy-project') ]);
 		await atom.packages.triggerDeferredActivationHooks();
 		await atom.packages.triggerActivationHook('core:loaded-shell-environment');
 		await atom.packages.activatePackage(path.join(__dirname, '..'));


### PR DESCRIPTION
Adding a checkbox to enable/disable Alloy projects when creating a new project:

![Screenshot_20231030_101446](https://github.com/tidev/pulsar-titanium/assets/4334997/e17d066e-a9f9-4b57-bb19-ae820827b65b)


_Note_: the change in `definitionsProvider-spec.js` was just a lint fix