### PR TITLE
feat(console-search): add search field with navigation and highlighting

### DIFF
--- a/styles/appc.less
+++ b/styles/appc.less
@@ -282,6 +282,18 @@
     p.error {
         color: #ff0000;
     }
+
+    span.highlight {
+        background-color: #ffff00;
+	color: #000;
+	padding-left: 0;
+	padding-right: 0;
+    }
+
+    .console-search-button {
+        margin-left: 0 !important;
+        margin-right: 0 !important;
+    }
 }
 
 .appc-new-project-dialog {


### PR DESCRIPTION
This commit introduces a search functionality to the console log screen.

A "Find" text field has been added, allowing users to input a search term.
- Users can navigate between occurrences of the search term using up/down arrows.
- All matching instances of the search term in the log are highlighted for better visibility.
- This feature improves usability by allowing users to quickly locate specific entries within the console logs.

re #81